### PR TITLE
dev: removing cointicker from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 
 # built files
 *.exe
-cointicker
+./cointicker


### PR DESCRIPTION
In order to ignore the built output `cointicker` we are also ignoring the cointicker
folder. Now I'm anchoring the ignore to the root of the project.